### PR TITLE
make daemon available

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ jobs:
       - image: node:14.9.0-alpine
     steps:
       - checkout
-      # - setup_remote_docker
+      - setup_remote_docker
       - run:
           name: Install docker CLI
           command: apk add --no-cache docker-cli


### PR DESCRIPTION
`setup_remote_docker` only provides the daemon - you need to have the cli (client) available in the container as well `apk add --no-cache docker-cli`.