### PR TITLE
specify docker version - to support the node image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,8 @@ jobs:
       - image: node:14.9.0-alpine
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 19.03.13
       - run:
           name: Install docker CLI
           command: apk add --no-cache docker-cli


### PR DESCRIPTION
error during the build: `error An unexpected error occurred: "EPERM: operation not permitted, copyfile '/usr/local/share/.cache/yarn/v6/npm-lodash-4.17.21-679591c564c3bffaae8454cf0b3df370c3d6911c-integrity/node_modules/lodash/LICENSE' -> '/app/node_modules/lodash/LICENSE'".
info If you think this is a bug, please open a bug report with the information provided in "/app/yarn-error.log".
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
The command '/bin/sh -c yarn' returned a non-zero code: 1`

context: `https://discuss.circleci.com/t/docker-build-fails-with-nonsensical-eperm-operation-not-permitted-copyfile/37364`